### PR TITLE
Fix to display current week

### DIFF
--- a/resources/gamepass.py
+++ b/resources/gamepass.py
@@ -207,6 +207,7 @@ elif mode == 2:
 
 elif mode == 3:
     season, week_code = params['url'].split(';', 1)
+    week_code = re.sub('".*', '', week_code)
     display_games(season, week_code)
     xbmcplugin.endOfDirectory(int(sys.argv[1]))
 


### PR DESCRIPTION
Ran in to this when trying to watch the KC - PHI game from tonight. Failed to load week 3 games, other weeks worked fine. It failed because of some extra information in the URL parameter sent in, see log below. This fix works but it might be better to find the source issue.

```
15:35:37 T:2922679104  NOTICE: [plugin.video.nfl.gamepass-0.2.0]: params: {'url': '2013;203" selected="true', 'mode': '3', 'name': 'Week 3'}
15:35:37 T:2922679104  NOTICE: [plugin.video.nfl.gamepass-0.2.0]: Request URL: https://gamepass.nfl.com/nflgp/servlets/games
15:35:37 T:2922679104  NOTICE: [plugin.video.nfl.gamepass-0.2.0]: Server: nginx/1.2.6
                                            Date: Fri, 20 Sep 2013 13:35:37 GMT
                                            Content-Type: text/xml;charset=UTF-8
                                            Content-Length: 232
                                            Connection: close
                                            Content-Language: en-US
15:35:37 T:2922679104   ERROR: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                             - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                            Error Type: <type 'exceptions.TypeError'>
                                            Error Contents: 'NoneType' object has no attribute '__getitem__'
                                            Traceback (most recent call last):
                                              File "/home/media/.xbmc/addons/xbmc-gamepass-master/default.py", line 6, in <module>
                                                from resources import gamepass
                                              File "/home/media/.xbmc/addons/xbmc-gamepass-master/resources/gamepass.py", line 210, in <module>
                                                display_games(season, week_code)
                                              File "/home/media/.xbmc/addons/xbmc-gamepass-master/resources/gamepass.py", line 42, in display_games
                                                games = get_weeks_games(season, week_code)
                                              File "/home/media/.xbmc/addons/xbmc-gamepass-master/resources/game_common.py", line 256, in get_weeks_games
                                                games = game_data_dict['games']['game']
                                            TypeError: 'NoneType' object has no attribute '__getitem__'
                                            -->End of Python script error report<--
15:35:37 T:3006777152   ERROR: GetDirectory - Error getting plugin://plugin.video.nfl.gamepass/?mode=3&name=Week%203&url=2013%3b203%22%20selected%3d%22true
15:35:37 T:3006777152   ERROR: CGUIMediaWindow::GetDirectory(plugin://plugin.video.nfl.gamepass/?mode=3&name=Week%203&url=2013%3b203%22%20selected%3d%22true) failed
```
