### PR TITLE
Add support for using HTTP proxies using no authentication or basic authentication.

### DIFF
--- a/default.py
+++ b/default.py
@@ -39,7 +39,21 @@ if addon.getSetting('debug') == 'false':
 else:
     debug = True
 
-gpr = pigskin(sub_name, cookiefile=cookie_file, debug=debug)
+proxy_config = None
+if addon.getSetting('proxy_enabled') == 'true':
+    proxy_config = {
+        'scheme': addon.getSetting('proxy_scheme'),
+        'host': addon.getSetting('proxy_host'),
+        'port': addon.getSetting('proxy_port'),
+        'auth': {
+            'username': addon.getSetting('proxy_username'),
+            'password': addon.getSetting('proxy_password'),
+        },
+    }
+    if proxy_config['auth']['username'] == '' and proxy_config['auth']['password'] == '':
+        proxy_config['auth'] = None
+
+gpr = pigskin(sub_name, proxy_config, cookiefile=cookie_file, debug=debug)
 
 def addon_log(string):
     if debug:

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -140,3 +140,43 @@ msgstr ""
 msgctxt "#30032"
 msgid "Coaches Film"
 msgstr ""
+
+msgctxt "#30033"
+msgid "Proxy Settings"
+msgstr ""
+
+msgctxt "#30034"
+msgid "Use an HTTP proxy to access Game Pass/Game Rewind"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Type"
+msgstr ""
+
+msgctxt "#30036"
+msgid "Server"
+msgstr ""
+
+msgctxt "#30037"
+msgid "Port"
+msgstr ""
+
+msgctxt "#30038"
+msgid "Username"
+msgstr ""
+
+msgctxt "#30039"
+msgid "Password"
+msgstr ""
+
+msgctxt "#30040"
+msgid "http"
+msgstr ""
+
+msgctxt "#30041"
+msgid "https"
+msgstr ""
+
+msgctxt "#30042"
+msgid "Only the following authentication schemes are supported: None and Basic"
+msgstr ""

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -13,6 +13,15 @@
     <setting id="local_tz" type="enum" label="30020" lvalues="30026|30027|30028" default="0"/>
     <setting id="hide_game_length" type="bool" label="30025" default="false"/>
   </category>
+  <category label="30033">
+    <setting id="proxy_enabled" type="bool" label="30034" default="false"/>
+    <setting id="proxy_scheme" type="select" label="30035" lvalues="30040|30041" default="http" enable="eq(-1,true)"/>
+    <setting id="proxy_host" type="text" label="30036" default="" enable="eq(-2,true)"/>
+    <setting id="proxy_port" type="number" label="30037" default="" enable="eq(-3,true)"/>
+    <setting type="lsep" label="30042"/>
+    <setting id="proxy_username" type="text" label="30038" default="" enable="eq(-5,true)"/>
+    <setting id="proxy_password" type="text" label="30039" default="" option="hidden" enable="eq(-6,true)"/>
+  </category>
   <category label="30031">
     <setting id="debug" type="bool" label="Add-on debugging" default="false"/>
   </category>


### PR DESCRIPTION
I know that XBMC/Kodi allows you to specify a proxy to use for the whole application, but it can sometimes be desirable to have a proxy setting specific for the add-on.  This adds such a proxy setting.
