### PR TITLE
Code Cleanup and minor bug fixes

### DIFF
--- a/default.py
+++ b/default.py
@@ -493,20 +493,12 @@ class GamepassGUI(xbmcgui.WindowXML):
                     self.display_shows_episodes(show_name, self.selected_season)
                 elif controlId == 230: # episode is clicked
                     self.init('game/episode')
-                    if self.weeks_list.getSelectedItem().getLabel() in ('Super Bowl Archives', 'Top 100 Players', 'Hard Knocks'):
-                        video_id = self.games_list.getSelectedItem().getProperty('id')
-                        video_streams = gpr.get_publishpoint_streams(video_id, 'video')
-                        addon_log('Video-Streams: %s' %video_streams)
-                        bitrate = self.select_bitrate(video_streams.keys())
-                        video_url = video_streams[bitrate]
-                        self.playUrl(video_url)
-                    else:
-                        url = self.games_list.getSelectedItem().getProperty('url')
-                        vtype = self.games_list.getSelectedItem().getProperty('type')
-                        episode_manifest = gpr.get_stream_manifest(vpath=url, vtype=vtype)
-                        bitrate = self.select_bitrate(episode_manifest.keys())
-                        episode_url = episode_manifest[bitrate]['full_url']
-                        self.playUrl(episode_url)
+                    video_id = self.games_list.getSelectedItem().getProperty('id')
+                    video_streams = gpr.get_publishpoint_streams(video_id, 'video')
+                    addon_log('Video-Streams: %s' %video_streams)
+                    bitrate = self.select_bitrate(video_streams.keys())
+                    video_url = video_streams[bitrate]
+                    self.playUrl(video_url)
                 elif controlId == 240: # Live content (though not games)
                     show_name = self.live_list.getSelectedItem().getLabel()
                     if show_name == 'NFL RedZone - Live':


### PR DESCRIPTION
I am not sure why there was used /encryptvideopath because every Video is also available with /publishpoint.
Without the if Clause in default.py 496 the bug with the if else Control also disappeared.
Finaly with the fallback of the Encoding in Coaches tape Bug  Invalid XML causes some games to fail #157 is also fixes
