### PR TITLE
Fixing bug to set the proxy scheme to one of http|https

### DIFF
--- a/default.py
+++ b/default.py
@@ -43,7 +43,7 @@ else:
 proxy_config = None
 if addon.getSetting('proxy_enabled') == 'true':
     proxy_config = {
-        'scheme': addon.getSetting('proxy_scheme'),
+        'scheme': 'https' if addon.getSetting('proxy_scheme') == '1' else 'http',
         'host': addon.getSetting('proxy_host'),
         'port': addon.getSetting('proxy_port'),
         'auth': {


### PR DESCRIPTION
Right now, the proxy_config 'scheme' value is set to '0' or '1' . This change maps the selected option to 'http' or 'https'  . 