### PR TITLE
16.0 Jarvis compatibility

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -7,7 +7,7 @@
     <import addon="xbmc.python" version="2.19.0"/>
     <import addon="script.module.xmltodict" version="0.9.0"/>
     <import addon="script.module.requests" version="2.4.3"/>
-    <import addon="xbmc.gui" version="5.3.0"/>
+    <import addon="xbmc.gui" version="5.10.0"/>
   </requires>
   <extension point="xbmc.python.pluginsource" library="default.py">
     <provides>video</provides>


### PR DESCRIPTION
Minimum GUI version was bumped up to 5.10.0 on Jarvis. You should probably push out a new version to the Kodi repository. :)

This solves #222.