### PR TITLE
Detect subscription type in pigskin

### DIFF
--- a/default.py
+++ b/default.py
@@ -25,16 +25,9 @@ LOGGING_PREFIX = '[%s-%s]' % (addon.getAddonInfo('id'), addon.getAddonInfo('vers
 if not xbmcvfs.exists(ADDON_PROFILE):
     xbmcvfs.mkdir(ADDON_PROFILE)
 
-if addon.getSetting('subscription') == '0':  # Game Pass International
-    cookie_file = os.path.join(ADDON_PROFILE, 'gp_cookie_file')
-    username = addon.getSetting('email')
-    password = addon.getSetting('password')
-    sub_name = 'international'
-else:  # Game Pass Domestic
-    cookie_file = os.path.join(ADDON_PROFILE, 'gr_cookie_file')
-    username = addon.getSetting('gr_email')
-    password = addon.getSetting('gr_password')
-    sub_name = 'domestic'
+cookie_file = os.path.join(ADDON_PROFILE, 'cookie_file')
+username = addon.getSetting('email')
+password = addon.getSetting('password')
 if addon.getSetting('debug') == 'false':
     debug = False
 else:
@@ -54,7 +47,7 @@ if addon.getSetting('proxy_enabled') == 'true':
     if addon.getSetting('proxy_auth') == 'false':
         proxy_config['auth'] = None
 
-gpr = pigskin(sub_name, proxy_config, cookie_file=cookie_file, debug=debug)
+gpr = pigskin(proxy_config, cookie_file=cookie_file, debug=debug)
 
 
 def addon_log(string):
@@ -93,7 +86,7 @@ class GamepassGUI(xbmcgui.WindowXML):
         self.games_list = self.window.getControl(230)
         self.live_list = self.window.getControl(240)
 
-        if gpr.subscription == 'domestic':
+        if gpr.get_subscription_type() == 'domestic':
             self.window.setProperty('domestic', 'true')
 
         if self.list_refill:
@@ -440,7 +433,7 @@ class GamepassGUI(xbmcgui.WindowXML):
                     self.main_selection = 'NFL Network'
                     self.window.setProperty('NW_clicked', 'true')
                     self.window.setProperty('GP_clicked', 'false')
-                    if gpr.subscription == 'international':
+                    if gpr.get_subscription_type() == 'international':
                         listitem = xbmcgui.ListItem('NFL Network - Live', 'NFL Network - Live')
                         self.live_items.append(listitem)
                         if gpr.redzone_on_air():

--- a/resources/language/Dutch/strings.po
+++ b/resources/language/Dutch/strings.po
@@ -77,18 +77,6 @@ msgctxt "#30016"
 msgid "Choose a game version"
 msgstr "Kies een wedstrijd versie"
 
-msgctxt "#30017"
-msgid "Game Pass International"
-msgstr "Game Pass Internationaal"
-
-msgctxt "#30018"
-msgid "Game Pass Domestic"
-msgstr "Game Pass Domestic"
-
-msgctxt "#30019"
-msgid "Subscription Type"
-msgstr "Kies abonnement"
-
 msgctxt "#30020"
 msgid "Date/time in local time"
 msgstr "Datum/tijd in lokale tijd"

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -77,18 +77,6 @@ msgctxt "#30016"
 msgid "Choose a game version"
 msgstr ""
 
-msgctxt "#30017"
-msgid "Game Pass International"
-msgstr ""
-
-msgctxt "#30018"
-msgid "Game Pass Domestic"
-msgstr ""
-
-msgctxt "#30019"
-msgid "Subscription Type"
-msgstr ""
-
 msgctxt "#30020"
 msgid "Localize Game Date/Time"
 msgstr ""

--- a/resources/language/German/strings.po
+++ b/resources/language/German/strings.po
@@ -77,18 +77,6 @@ msgctxt "#30016"
 msgid "Choose a game version"
 msgstr "Wähle eine Spiel Version"
 
-msgctxt "#30017"
-msgid "Game Pass International"
-msgstr ""
-
-msgctxt "#30018"
-msgid "Game Pass Domestic"
-msgstr ""
-
-msgctxt "#30019"
-msgid "Subscription Type"
-msgstr "Abonnement wählen"
-
 msgctxt "#30020"
 msgid "Date/time in local time"
 msgstr "Uhrzeit in lokaler Zeitzone"

--- a/resources/lib/pigskin.py
+++ b/resources/lib/pigskin.py
@@ -18,9 +18,9 @@ import xmltodict
 
 
 class pigskin(object):
-    def __init__(self, subscription, proxy_config, cookie_file, debug=False):
-        self.subscription = subscription
+    def __init__(self, proxy_config, cookie_file, debug=False):
         self.debug = debug
+        self.subscription = ''
         self.base_url = 'https://gamepass.nfl.com/nflgp'
         self.servlets_url = 'http://gamepass.nfl.com/nflgp/servlets'
         self.simpleconsole_url = self.servlets_url + '/simpleconsole'
@@ -62,7 +62,15 @@ class pigskin(object):
             self.log('locEDLBaseUrl: %s' % self.locEDLBaseUrl)
         except xmltodict.expat.ExpatError:
             return False
-
+            
+        # get subscription type
+        if '<isGPDomestic>' in sc_data:
+            self.subscription = 'domestic'
+            self.log('NFL Game Pass Domestic detected.')
+        else:
+            self.subscription = 'international'
+            self.log('NFL Game Pass International detected.')
+            
         self.log('Debugging enabled.')
         self.log('Python Version: %s' % sys.version)
 
@@ -485,3 +493,21 @@ class pigskin(object):
             return True
         else:
             return False
+
+    def get_subscription_type(self):
+        """Return whether the user is eligible for Game Pass Domestic/International."""
+        if self.subscription:
+            return self.subscription
+        else:
+            url = self.simpleconsole_url
+            post_data = {'isFlex': 'true'}
+            sc_data = self.make_request(url=url, method='post', payload=post_data)
+            
+            if '<isGPDomestic>' in sc_data:
+                subscription = 'domestic'
+                self.log('NFL Game Pass Domestic detected.')
+            else:
+                subscription = 'international'
+                self.log('NFL Game Pass International detected.')
+                
+            return subscription

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1,10 +1,7 @@
 <settings>
   <category label="30029">
-    <setting id="subscription" type="enum" label="30019" lvalues="30017|30018" default='0'/>
-    <setting id="email" type="text" label="30001" default="" visible="eq(-1,0)" enable="eq(-1,0)"/>
-    <setting id="password" type="text" label="30002" default="" option="hidden" visible="eq(-2,0)" enable="eq(-2,0)"/>
-    <setting id="gr_email" type="text" label="30001" default="" visible="eq(-3,1)" enable="eq(-3,1)"/>
-    <setting id="gr_password" type="text" label="30002" default="" option="hidden" visible="eq(-4,1)" enable="eq(-4,1)"/>
+    <setting id="email" type="text" label="30001" default=""/>
+    <setting id="password" type="text" label="30002" default="" option="hidden" visible="!eq(-1,)" enable="!eq(-1,)"/>
   </category>
   <category label="30030">
     <setting id="preferred_bitrate" type="select" label="30003" lvalues="30004|30005|30006|30007|30008|30009|30010|30011|30012" default="8"/>


### PR DESCRIPTION
There's really no need to let the user select subscription type as the info is available in the simpleconsole response.